### PR TITLE
Add a `satisfies` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This crate extends `Option` with additional methods, currently:
 - `contains`
 - `map_or2` (as a replacement for `map_or`)
 - `map_or_else2` (as a replacement for `map_or_else`)
+- `satisfies`
 
 Its sister crate is [`result-ext`](https://github.com/soc/result-ext), which extends `Result`.
 
@@ -63,5 +64,16 @@ fn example_map_or_else2() {
     
     let x: Option<&str> = None;
     assert_eq!(x.map_or_else2(|v| v.len(), || 2 * k), 46);
+}
+
+fn example_satisfies() {
+    let x = Some(10);
+    assert!(x.satisfies(|&n| n % 2 == 0));
+
+    let y = Some(13);
+    assert!(!y.satisfies(|&n| n % 2 == 0));
+
+    let z = None::<i32>;
+    assert!(!z.satisfies(|&n| n % 2 == 0));
 }
 ```

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -17,4 +17,11 @@ impl<T> OptionExt<T> for Option<T> {
     fn map_or_else2<U, F: FnOnce(T) -> U, D: FnOnce() -> U>(self, f: F, default: D) -> U {
         self.map_or_else(default, f)
     }
+
+    fn satisfies<P: FnOnce(&T) -> bool>(&self, predicate: P) -> bool {
+        match self {
+            Some(v) => predicate(v),
+            None => false,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,4 +68,23 @@ pub trait OptionExt<T> {
     /// ```
     #[must_use]
     fn map_or_else2<U, F: FnOnce(T) -> U, D: FnOnce() -> U>(self, f: F, default: D) -> U;
+
+    /// Returns whether the contained value satisfies the given predicate,
+    /// or `false` if the option is [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use option_ext::OptionExt;
+    ///
+    /// let x = Some(10);
+    /// assert!(x.satisfies(|&n| n % 2 == 0));
+    ///
+    /// let y = Some(13);
+    /// assert!(!y.satisfies(|&n| n % 2 == 0));
+    ///
+    /// let z = None::<i32>;
+    /// assert!(!z.satisfies(|&n| n % 2 == 0));
+    /// ```
+    fn satisfies<P: FnOnce(&T) -> bool>(&self, predicate: P) -> bool;
 }


### PR DESCRIPTION
This is in my opinion a fairly common use case for options, yet usually solved with "hacks" like `.filter(...).is_some()`, `.map_or(false, ...)`